### PR TITLE
Implementing Survey Auto Closure over Websocket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,5 +70,14 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20231013</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/group/thirtyone/controllers/HomePageController.java
+++ b/src/main/java/group/thirtyone/controllers/HomePageController.java
@@ -1,22 +1,14 @@
 package group.thirtyone.controllers;
 
-import group.thirtyone.othercomponents.SurveyMessage;
 import group.thirtyone.persistencerepositories.SurveyRepository;
-import group.thirtyone.surveycomponents.Question;
 import group.thirtyone.surveycomponents.Survey;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.util.HtmlUtils;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,7 +44,7 @@ public class HomePageController {
             }
             else
             {
-                return "closedsurvey";
+                return "closed_survey";
             }
         }
         return "error";

--- a/src/main/java/group/thirtyone/controllers/HomePageController.java
+++ b/src/main/java/group/thirtyone/controllers/HomePageController.java
@@ -1,15 +1,22 @@
 package group.thirtyone.controllers;
 
+import group.thirtyone.othercomponents.SurveyMessage;
 import group.thirtyone.persistencerepositories.SurveyRepository;
 import group.thirtyone.surveycomponents.Question;
 import group.thirtyone.surveycomponents.Survey;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.HtmlUtils;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,4 +50,5 @@ public class HomePageController {
         }
         return "error";
     }
+
 }

--- a/src/main/java/group/thirtyone/controllers/HomePageController.java
+++ b/src/main/java/group/thirtyone/controllers/HomePageController.java
@@ -45,8 +45,15 @@ public class HomePageController {
         Optional<Survey> result = surveyRepository.findById(id);
         if (result.isPresent()) {
             Survey survey = result.get();
-            model.addAttribute("survey", survey);
-            return "survey";
+            if (survey.isActive())
+            {
+                model.addAttribute("survey", survey);
+                return "survey";
+            }
+            else
+            {
+                return "closedsurvey";
+            }
         }
         return "error";
     }

--- a/src/main/java/group/thirtyone/controllers/SocketTextHandler.java
+++ b/src/main/java/group/thirtyone/controllers/SocketTextHandler.java
@@ -1,0 +1,23 @@
+package group.thirtyone.controllers;
+
+import org.json.JSONObject;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+
+@Component
+public class SocketTextHandler extends TextWebSocketHandler {
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message)
+            throws InterruptedException, IOException {
+
+        String payload = message.getPayload();
+        JSONObject jsonObject = new JSONObject(payload);
+        session.sendMessage(new TextMessage("Hi " + jsonObject.get("message") + " how may we help you?"));
+
+    }
+}

--- a/src/main/java/group/thirtyone/controllers/SocketTextHandler.java
+++ b/src/main/java/group/thirtyone/controllers/SocketTextHandler.java
@@ -1,12 +1,17 @@
 package group.thirtyone.controllers;
 
+import group.thirtyone.persistencerepositories.SurveyRepository;
+import group.thirtyone.surveycomponents.Survey;
 import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 @Component
@@ -14,25 +19,55 @@ public class SocketTextHandler extends TextWebSocketHandler {
 
     private static Set<WebSocketSession> sessions = new HashSet<>();
 
+    private SurveyRepository surveyRepository;
+
+    public SocketTextHandler(SurveyRepository surveyRepository) {
+        this.surveyRepository = surveyRepository;
+    }
+
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-        System.out.println(session + " Connected to group thirtyone");
         sessions.add(session);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        sessions.remove(session);
     }
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         String payload = message.getPayload();
         JSONObject jsonObject = new JSONObject(payload);
+        String msgtoSend = "";
+        switch (jsonObject.get("type").toString()) {
+            case "CLOSE_SURVEY":
+                System.out.println("Closing survey");
+                closeSurvey(jsonObject.get("id").toString());
+                msgtoSend = "CLOSE #" + jsonObject.get("id").toString() + "#";
+                break;
+        }
 
         for (WebSocketSession webSocketSession : sessions) {
             if (webSocketSession.isOpen()) {
                 try {
-                    webSocketSession.sendMessage(new TextMessage("Hi " + jsonObject.get("message") + " how may we help you?"));
+                    webSocketSession.sendMessage(new TextMessage(msgtoSend));
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
             }
         }
     }
+
+    private void closeSurvey(String id)
+    {
+        Long surveyId = Long.parseLong(id);
+        Optional<Survey> surveyInQuestion = surveyRepository.findById(surveyId);
+        if (surveyInQuestion.isPresent()) {
+            Survey survey = surveyInQuestion.get();
+            survey.close();
+            surveyRepository.save(survey);
+        }
+    }
+
 }

--- a/src/main/java/group/thirtyone/controllers/SocketTextHandler.java
+++ b/src/main/java/group/thirtyone/controllers/SocketTextHandler.java
@@ -5,19 +5,34 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
-
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 @Component
 public class SocketTextHandler extends TextWebSocketHandler {
 
-    @Override
-    public void handleTextMessage(WebSocketSession session, TextMessage message)
-            throws InterruptedException, IOException {
+    private static Set<WebSocketSession> sessions = new HashSet<>();
 
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        System.out.println(session + " Connected to group thirtyone");
+        sessions.add(session);
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         String payload = message.getPayload();
         JSONObject jsonObject = new JSONObject(payload);
-        session.sendMessage(new TextMessage("Hi " + jsonObject.get("message") + " how may we help you?"));
 
+        for (WebSocketSession webSocketSession : sessions) {
+            if (webSocketSession.isOpen()) {
+                try {
+                    webSocketSession.sendMessage(new TextMessage("Hi " + jsonObject.get("message") + " how may we help you?"));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
     }
 }

--- a/src/main/java/group/thirtyone/controllers/SocketTextHandler.java
+++ b/src/main/java/group/thirtyone/controllers/SocketTextHandler.java
@@ -3,7 +3,6 @@ package group.thirtyone.controllers;
 import group.thirtyone.persistencerepositories.SurveyRepository;
 import group.thirtyone.surveycomponents.Survey;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;

--- a/src/main/java/group/thirtyone/controllers/WebSocketConfig.java
+++ b/src/main/java/group/thirtyone/controllers/WebSocketConfig.java
@@ -1,5 +1,7 @@
 package group.thirtyone.controllers;
 
+import group.thirtyone.persistencerepositories.SurveyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.*;
@@ -9,7 +11,10 @@ import org.springframework.web.socket.handler.AbstractWebSocketHandler;
 @EnableWebSocket
 public class WebSocketConfig implements WebSocketConfigurer {
 
+    @Autowired
+    private SurveyRepository surveyRepository;
+
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(new SocketTextHandler(), "/comms/survey-speak").setAllowedOrigins("*");
+        registry.addHandler(new SocketTextHandler(surveyRepository), "/comms/survey-speak").setAllowedOrigins("*");
     }
 }

--- a/src/main/java/group/thirtyone/controllers/WebSocketConfig.java
+++ b/src/main/java/group/thirtyone/controllers/WebSocketConfig.java
@@ -1,0 +1,15 @@
+package group.thirtyone.controllers;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.*;
+import org.springframework.web.socket.handler.AbstractWebSocketHandler;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(new SocketTextHandler(), "/comms/survey-speak");
+    }
+}

--- a/src/main/java/group/thirtyone/controllers/WebSocketConfig.java
+++ b/src/main/java/group/thirtyone/controllers/WebSocketConfig.java
@@ -10,6 +10,6 @@ import org.springframework.web.socket.handler.AbstractWebSocketHandler;
 public class WebSocketConfig implements WebSocketConfigurer {
 
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(new SocketTextHandler(), "/comms/survey-speak");
+        registry.addHandler(new SocketTextHandler(), "/comms/survey-speak").setAllowedOrigins("*");
     }
 }

--- a/src/main/java/group/thirtyone/othercomponents/SurveyMessage.java
+++ b/src/main/java/group/thirtyone/othercomponents/SurveyMessage.java
@@ -1,0 +1,27 @@
+package group.thirtyone.othercomponents;
+
+public class SurveyMessage {
+    private String message;
+    private Long id;
+
+    public SurveyMessage(String message, Long id) {
+        this.message = message;
+        this.id = id;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/group/thirtyone/surveycomponents/Survey.java
+++ b/src/main/java/group/thirtyone/surveycomponents/Survey.java
@@ -23,6 +23,8 @@ public class Survey {
 
     private String name;
 
+    private boolean active;
+
     @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private List<MultipleChoice> multipleChoiceQuestions;
 
@@ -39,6 +41,7 @@ public class Survey {
         multipleChoiceQuestions = new ArrayList<>();
         numberRangeQuestions = new ArrayList<>();
         openEndedQuestions = new ArrayList<>();
+        active = true;
     }
 
     /**
@@ -112,4 +115,14 @@ public class Survey {
     public Long getId() {
         return this.id;
     }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void close()
+    {
+        active = false;
+    }
+
 }

--- a/src/main/resources/static/js/results.js
+++ b/src/main/resources/static/js/results.js
@@ -19,11 +19,9 @@ function viewQuestion(evt, questionType) {
     evt.currentTarget.className += " active";
 }
 
-function viewSurvey(evt, survey) {
+function viewSurvey(evt, survey, id) {
     // Declare all variables
     var i, tabcontent, tablinks;
-
-    console.log(survey)
 
     // Get all elements with class="tabcontent" and hide them
     tabcontent = document.getElementsByClassName("vtabcontent");
@@ -39,5 +37,6 @@ function viewSurvey(evt, survey) {
 
     // Show the current tab, and add an "active" class to the link that opened the tab
     document.getElementById(survey).style.display = "block";
+    document.getElementById("currentid").text(id);
     evt.currentTarget.className += " active";
 }

--- a/src/main/resources/static/js/survey.js
+++ b/src/main/resources/static/js/survey.js
@@ -1,10 +1,13 @@
 var ws;
+var currid;
 
-function connect() {
+function connect(id) {
+    currid = "#" + id + "#"
     ws = new WebSocket('ws://localhost:8080/comms/survey-speak');
-    console.log("connected")
     ws.onmessage = function(data) {
-        console.log(data.data);
+        if (data.data.includes("CLOSE") && data.data.includes(currid)) {
+            location.reload();
+        }
     }
     //setConnected(true);
 }

--- a/src/main/resources/static/js/survey.js
+++ b/src/main/resources/static/js/survey.js
@@ -1,0 +1,29 @@
+var ws;
+
+function connect() {
+    ws = new WebSocket('ws://localhost:8080/comms/survey-speak');
+    ws.onmessage = function(data) {
+        console.log(data.data);
+    }
+    //setConnected(true);
+}
+
+function disconnect() {
+    if (ws != null) {
+        ws.close();
+    }
+    //setConnected(false);
+    console.log("Websocket is in disconnected state");
+}
+
+function sendData(message, id) {
+    var data = JSON.stringify({
+        'message' : message,
+        'id': id
+    })
+    ws.send(data);
+}
+
+// function helloWorld(message) {
+//     $("#helloworldmessage").append(" " + message + "");
+// }

--- a/src/main/resources/static/js/userdash.js
+++ b/src/main/resources/static/js/userdash.js
@@ -18,10 +18,11 @@ function disconnect() {
 
 function sendData(message, id) {
     var data = JSON.stringify({
-        'message' : message,
+        'type': "CLOSE_SURVEY",
         'id': id
     })
     ws.send(data);
+    $("#surveystatus" + id).text("Survey Status: Closed")
 }
 
 // function helloWorld(message) {

--- a/src/main/resources/static/js/userdash.js
+++ b/src/main/resources/static/js/userdash.js
@@ -2,7 +2,6 @@ var ws;
 
 function connect() {
     ws = new WebSocket('ws://localhost:8080/comms/survey-speak');
-    console.log("connected")
     ws.onmessage = function(data) {
         console.log(data.data);
     }
@@ -15,6 +14,14 @@ function disconnect() {
     }
     //setConnected(false);
     console.log("Websocket is in disconnected state");
+}
+
+function sendData(message, id) {
+    var data = JSON.stringify({
+        'message' : message,
+        'id': id
+    })
+    ws.send(data);
 }
 
 // function helloWorld(message) {

--- a/src/main/resources/templates/closed_survey.html
+++ b/src/main/resources/templates/closed_survey.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Error</title>
+    <title>Survey Closed</title>
 </head>
 <body>
 <h1>Survey Is Closed, Thank you</h1>

--- a/src/main/resources/templates/closedsurvey.html
+++ b/src/main/resources/templates/closedsurvey.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Error</title>
+</head>
+<body>
+<h1>Survey Is Closed, Thank you</h1>
+<br>
+<a href="/">Back to Home page</a>
+</body>
+</html>

--- a/src/main/resources/templates/survey.html
+++ b/src/main/resources/templates/survey.html
@@ -4,12 +4,19 @@
     <meta charset="UTF-8">
     <title>View Survey</title>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7.0.0/bundles/stomp.umd.min.js"></script>
+    <script type="text/javascript" th:src="@{/js/survey.js}"></script>
 </head>
 <body>
 <br>
 <a href="/">Back to list</a>
 <p>Survey Name:</p>
 <p th:text="${survey.name}"></p>
+
+<script>
+    connect();
+</script>
+
 
 <form class="surveySubmission">
     <div th:each="question,iter : ${survey.getQuestions()}">

--- a/src/main/resources/templates/survey.html
+++ b/src/main/resources/templates/survey.html
@@ -14,7 +14,7 @@
 <p th:text="${survey.name}"></p>
 
 <script>
-    connect();
+    connect("[[${survey.getId()}]]");
 </script>
 
 

--- a/src/main/resources/templates/userdash.html
+++ b/src/main/resources/templates/userdash.html
@@ -7,7 +7,7 @@
     <link th:href="@{/css/results.css}" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7.0.0/bundles/stomp.umd.min.js"></script>
     <script type="text/javascript" th:src="@{/js/results.js}"></script>
-    <script type="text/javascript" th:src="@{/js/survey.js}"></script>
+    <script type="text/javascript" th:src="@{/js/userdash.js}"></script>
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script src="https://canvasjs.com/assets/script/canvasjs.min.js"></script>
 </head>

--- a/src/main/resources/templates/userdash.html
+++ b/src/main/resources/templates/userdash.html
@@ -19,12 +19,17 @@
 
 <p id="currentid" hidden></p>
 
+<script>
+    // Get the element with id="defaultOpen" and click on it
+    connect();
+</script>
+
 <div th:each="survey,seriter : ${surveys}" th:id="${survey.name}" class="vtabcontent">
     <div class="htab">
         <button class="htablinks" th:onclick="|viewQuestion(event, 'OpenEnded${survey.getId()}')|" th:id="defaultOpen+${survey.getId()}">Open Ended</button>
         <button class="htablinks" th:onclick="|viewQuestion(event, 'MultipleChoice${survey.getId()}')|">Multiple Choice</button>
         <button class="htablinks" th:onclick="|viewQuestion(event, 'NumberRange${survey.getId()}')|">Number Range</button>
-        <button class="htablinks" th:onclick="|viewQuestion(event, 'Settings${survey.getId()}')|">Settings</button>
+        <button class="htablinks" th:onclick="|viewQuestion(event, 'Settings${survey.getId()}')|">Status</button>
     </div>
 
     <script>
@@ -117,13 +122,14 @@
         </div>
     </div>
     <div th:id="Settings+${survey.getId()}" class="htabcontent">
-        <h3>Settings</h3>
-        <script>
-            // Get the element with id="defaultOpen" and click on it
-            connect();
-        </script>
+        <h3>Status</h3>
+        <div th:switch="${survey.isActive()}">
+            <p th:id="surveystatus + ${survey.getId}" th:case="true">Survey Status: Active</p>
+            <p th:id="surveystatus + ${survey.getId}" th:case="false">Survey Status: Closed</p>
+        </div>
+
         <div>
-            <button id="connect" class="btn btn-default">Connect</button>
+        <h3>Danger</h3>
             <button id="close" th:onclick="|sendData('This is a test message!!', '${survey.getId()}')|">Close Survey</button>
         </div>
     </div>

--- a/src/main/resources/templates/userdash.html
+++ b/src/main/resources/templates/userdash.html
@@ -5,22 +5,26 @@
     <title>Survey Results</title>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <link th:href="@{/css/results.css}" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7.0.0/bundles/stomp.umd.min.js"></script>
     <script type="text/javascript" th:src="@{/js/results.js}"></script>
+    <script type="text/javascript" th:src="@{/js/survey.js}"></script>
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script src="https://canvasjs.com/assets/script/canvasjs.min.js"></script>
 </head>
 <body>
 
 <div class="vtab">
-    <button th:each="survey,iter : ${surveys}" th:id="surveyclass+${survey.getId()}" class="vtablinks" th:data-name="${survey.name}" th:onclick="viewSurvey(event, this.getAttribute('data-name'))" th:text="${survey.name}"></button>
+    <button th:each="survey,iter : ${surveys}" th:id="surveyclass+${survey.getId()}" class="vtablinks" th:data-name="${survey.name}" th:data-id="${survey.getId()}" th:onclick="viewSurvey(event, this.getAttribute('data-name'), this.getAttribute('data-id'))" th:text="${survey.name}"></button>
 </div>
 
+<p id="currentid" hidden></p>
 
 <div th:each="survey,seriter : ${surveys}" th:id="${survey.name}" class="vtabcontent">
     <div class="htab">
         <button class="htablinks" th:onclick="|viewQuestion(event, 'OpenEnded${survey.getId()}')|" th:id="defaultOpen+${survey.getId()}">Open Ended</button>
         <button class="htablinks" th:onclick="|viewQuestion(event, 'MultipleChoice${survey.getId()}')|">Multiple Choice</button>
         <button class="htablinks" th:onclick="|viewQuestion(event, 'NumberRange${survey.getId()}')|">Number Range</button>
+        <button class="htablinks" th:onclick="|viewQuestion(event, 'Settings${survey.getId()}')|">Settings</button>
     </div>
 
     <script>
@@ -110,6 +114,17 @@
                     });
                 </script>
             </div><br/>
+        </div>
+    </div>
+    <div th:id="Settings+${survey.getId()}" class="htabcontent">
+        <h3>Settings</h3>
+        <script>
+            // Get the element with id="defaultOpen" and click on it
+            connect();
+        </script>
+        <div>
+            <button id="connect" class="btn btn-default">Connect</button>
+            <button id="close" th:onclick="|sendData('This is a test message!!', '${survey.getId()}')|">Close Survey</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Added the ability for a survey owner to close a survey #8, #10, which also closes all open sessions of a survey (following #8). The websocket implementation is simple, and messages are filtered through javascript files attached to each survey. This websocket implementation could also be used for any other communication we would want to add through it.